### PR TITLE
Add imports for Storage and Camera to PhotoService and Tab2Component test bed

### DIFF
--- a/src/app/services/photo.service.spec.ts
+++ b/src/app/services/photo.service.spec.ts
@@ -1,9 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 
+import { IonicStorageModule } from '@ionic/storage';
+import { Camera } from '@ionic-native/camera/ngx';
+
 import { PhotoService } from './photo.service';
 
 describe('PhotoService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [IonicStorageModule.forRoot()],
+    providers: [Camera]
+  }));
 
   it('should be created', () => {
     const service: PhotoService = TestBed.get(PhotoService);

--- a/src/app/tab2/tab2.page.spec.ts
+++ b/src/app/tab2/tab2.page.spec.ts
@@ -1,6 +1,9 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { IonicStorageModule } from '@ionic/storage';
+import { Camera } from '@ionic-native/camera/ngx';
+
 import { Tab2Page } from './tab2.page';
 
 describe('Tab2Page', () => {
@@ -9,6 +12,8 @@ describe('Tab2Page', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [IonicStorageModule.forRoot()],
+      providers: [Camera],
       declarations: [Tab2Page],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();


### PR DESCRIPTION
Addresses npm test issues in https://github.com/ionic-team/ionic-cli/issues/4287